### PR TITLE
src/grafana/jaeger: fix Trace-to-Logs integration query

### DIFF
--- a/src/grafana/provisioning/datasources/victoriatraces.yaml
+++ b/src/grafana/provisioning/datasources/victoriatraces.yaml
@@ -19,4 +19,4 @@ datasources:
         filterByTraceID: true
         filterBySpanID: true
         customQuery: true
-        query: traceId:"$${__trace.traceId}" AND spanId:"$${__span.spanId}"
+        query: trace_id:="$${__trace.traceId}" AND spanId:"$${__span.spanId}"

--- a/src/grafana/provisioning/datasources/victoriatraces.yaml
+++ b/src/grafana/provisioning/datasources/victoriatraces.yaml
@@ -19,4 +19,4 @@ datasources:
         filterByTraceID: true
         filterBySpanID: true
         customQuery: true
-        query: trace_id:="$${__trace.traceId}" AND spanId:"$${__span.spanId}"
+        query: trace_id:="$${__trace.traceId}" AND span_id:="$${__span.spanId}"


### PR DESCRIPTION
VictoriaLogs stores log entries with camel-cased field names in this demo. With this change, the filed names and filtering become correct when clicking on the link from traces to logs.